### PR TITLE
feat: タスクの一覧取得

### DIFF
--- a/spring/src/main/java/com/example/todo/controller/api/tasks/TaskSearchController.java
+++ b/spring/src/main/java/com/example/todo/controller/api/tasks/TaskSearchController.java
@@ -1,0 +1,13 @@
+package com.example.todo.controller.api.tasks;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskSearchController {
+
+  public TaskSearchController() {
+    // Constructor
+  }
+}

--- a/spring/src/main/java/com/example/todo/controller/api/tasks/TaskSearchController.java
+++ b/spring/src/main/java/com/example/todo/controller/api/tasks/TaskSearchController.java
@@ -1,13 +1,36 @@
 package com.example.todo.controller.api.tasks;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.example.todo.dto.request.tasks.TaskSearchRequest;
+import com.example.todo.dto.response.tasks.TaskBaseResponse;
+import com.example.todo.service.tasks.TaskSearchService;
+import jakarta.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/tasks")
 public class TaskSearchController {
 
-  public TaskSearchController() {
-    // Constructor
+  private final TaskSearchService taskSearchService;
+
+  public TaskSearchController(TaskSearchService taskSearchService) {
+    this.taskSearchService = taskSearchService;
+  }
+
+  /**
+   * @ModelAttribute メソッドの引数に付与するアノテーション。リクエストパラメータを受け取るために使用する。
+   *                 リクエストパラメータとは、HTTPリクエストのクエリパラメータやフォームパラメータのこと。
+   *                 例えば、`/api/tasks?status=xxx`のようなリクエストの status パラメータを受け取る場合に使用する。
+   */
+  @GetMapping
+  public ResponseEntity<List<TaskBaseResponse>> invoke(
+      @Valid @ModelAttribute TaskSearchRequest request) {
+    List<TaskBaseResponse> tasks = this.taskSearchService.invoke(request);
+
+    return ResponseEntity.ok(tasks);
   }
 }

--- a/spring/src/main/java/com/example/todo/dto/request/tasks/TaskSearchRequest.java
+++ b/spring/src/main/java/com/example/todo/dto/request/tasks/TaskSearchRequest.java
@@ -1,0 +1,12 @@
+package com.example.todo.dto.request.tasks;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TaskSearchRequest {
+
+  // プロジェクト単位で絞り込みするためのパラメータ
+  private final Integer projectId;
+}

--- a/spring/src/main/java/com/example/todo/repository/TaskRepository.java
+++ b/spring/src/main/java/com/example/todo/repository/TaskRepository.java
@@ -1,8 +1,17 @@
 package com.example.todo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import com.example.todo.entity.Task;
 
-public interface TaskRepository extends JpaRepository<Task, Integer> {
+/**
+ * Task Entity に対するデータ操作を行うためのリポジトリインターフェイス。
+ *
+ * JpaRepository を継承することで、データの追加・更新・削除などの基本的な操作を簡単に実装することができる。
+ *
+ * JpaSpecificationExecutor を継承することで、動的な検索条件を生成するためのメソッドを提供する。
+ */
+public interface TaskRepository
+    extends JpaRepository<Task, Integer>, JpaSpecificationExecutor<Task> {
 
 }

--- a/spring/src/main/java/com/example/todo/repository/specification/TaskSpecification.java
+++ b/spring/src/main/java/com/example/todo/repository/specification/TaskSpecification.java
@@ -1,0 +1,35 @@
+package com.example.todo.repository.specification;
+
+import org.springframework.data.jpa.domain.Specification;
+import com.example.todo.entity.Task;
+
+/**
+ * Task Entityに対する検索条件を生成するクラス。
+ *
+ * こちらをRepository層で使用することで、検索条件を動的に生成することができる。
+ */
+public class TaskSpecification {
+
+  /**
+   * プロジェクトが null の場合の検索条件を生成する。
+   *
+   * @return プロジェクトが null の場合の検索条件
+   */
+  public Specification<Task> projectIdIsNull() {
+    // root: 検索対象のエンティティを指す。（ここでは Task Entity）
+    // query: クエリの設定をするためのクエリを指す。ここでは未使用。
+    // _____| 例えば、query.orderBy(builder.asc(root.get("id"))); のように、並び替え条件を設定することができる。
+    // _____| 他にも、「取得フィールドの指定」や「グループ化」なども可能。
+    // builder: 検索条件（WHERE句）を生成するためのビルダーを指す。
+    // _______| builder.equal() や builder.isNull() など、様々な検索条件を生成するメソッドが用意されている。
+    return (root, query, builder) -> builder.isNull(root.get("project"));
+  }
+
+  public Specification<Task> projectIdEqual(Integer projectId) {
+    if (projectId == null) {
+      return null;
+    }
+
+    return (root, query, builder) -> builder.equal(root.get("project").get("id"), projectId);
+  }
+}

--- a/spring/src/main/java/com/example/todo/service/tasks/TaskSearchService.java
+++ b/spring/src/main/java/com/example/todo/service/tasks/TaskSearchService.java
@@ -4,8 +4,11 @@ import com.example.todo.dto.request.tasks.TaskSearchRequest;
 import com.example.todo.dto.response.tasks.TaskBaseResponse;
 import com.example.todo.entity.Task;
 import com.example.todo.repository.TaskRepository;
+import com.example.todo.repository.specification.TaskSpecification;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,11 +21,40 @@ public class TaskSearchService {
   }
 
   public List<TaskBaseResponse> invoke(TaskSearchRequest request) {
-    // TODO: 以下の処理だと、全てのタスクを取得してしまう。本来は、リクエストパラメータに応じて取得するタスクを絞り込む必要がある。
-    List<Task> tasks = this.taskRepository.findAll();
+    Specification<Task> spec = this.generateSpecification(request);
+    Sort sort = this.generateSort();
+
+    // Task Entity のリストを取得
+    // 引数に検索条件とソート条件を指定することで、条件に合致する Task Entity のリストを取得できる
+    List<Task> tasks = this.taskRepository.findAll(spec, sort);
 
     // Task Entity のリストを、TaskBaseResponse のリストに変換して返す
     // .collect(Collectors.toList()) は、Stream の要素を List に変換するメソッド
     return tasks.stream().map(task -> new TaskBaseResponse(task)).collect(Collectors.toList());
+  }
+
+  /**
+   * Task Entity に対する検索条件を生成する。
+   *
+   * @param request
+   * @return
+   */
+  private Specification<Task> generateSpecification(TaskSearchRequest request) {
+    TaskSpecification spec = new TaskSpecification();
+
+    // プロジェクトIDが null の場合は、projectIdIsNull() を、それ以外の場合は projectIdEqual() を使用する
+    return request.getProjectId() == null ? Specification.where(spec.projectIdIsNull())
+        : Specification.where(spec.projectIdEqual(request.getProjectId()));
+  }
+
+  /**
+   * Task Entity に対するソート条件を生成する。
+   *
+   * @return
+   */
+  private Sort generateSort() {
+    // completedAt降順 > deadlineAt昇順 > id降順 の並びになるようにソート条件を設定
+    return Sort.by(Sort.Order.desc("completedAt"), Sort.Order.asc("deadlineAt"),
+        Sort.Order.desc("id"));
   }
 }

--- a/spring/src/main/java/com/example/todo/service/tasks/TaskSearchService.java
+++ b/spring/src/main/java/com/example/todo/service/tasks/TaskSearchService.java
@@ -1,0 +1,8 @@
+package com.example.todo.service.tasks;
+
+public class TaskSearchService {
+
+  public TaskSearchService() {
+    // Constructor
+  }
+}

--- a/spring/src/main/java/com/example/todo/service/tasks/TaskSearchService.java
+++ b/spring/src/main/java/com/example/todo/service/tasks/TaskSearchService.java
@@ -1,8 +1,28 @@
 package com.example.todo.service.tasks;
 
+import com.example.todo.dto.request.tasks.TaskSearchRequest;
+import com.example.todo.dto.response.tasks.TaskBaseResponse;
+import com.example.todo.entity.Task;
+import com.example.todo.repository.TaskRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
 public class TaskSearchService {
 
-  public TaskSearchService() {
-    // Constructor
+  private final TaskRepository taskRepository;
+
+  public TaskSearchService(TaskRepository taskRepository) {
+    this.taskRepository = taskRepository;
+  }
+
+  public List<TaskBaseResponse> invoke(TaskSearchRequest request) {
+    // TODO: 以下の処理だと、全てのタスクを取得してしまう。本来は、リクエストパラメータに応じて取得するタスクを絞り込む必要がある。
+    List<Task> tasks = this.taskRepository.findAll();
+
+    // Task Entity のリストを、TaskBaseResponse のリストに変換して返す
+    // .collect(Collectors.toList()) は、Stream の要素を List に変換するメソッド
+    return tasks.stream().map(task -> new TaskBaseResponse(task)).collect(Collectors.toList());
   }
 }

--- a/spring/src/test/java/com/example/todo/controller/api/tasks/TaskSearchControllerTest.java
+++ b/spring/src/test/java/com/example/todo/controller/api/tasks/TaskSearchControllerTest.java
@@ -1,0 +1,71 @@
+package com.example.todo.controller.api.tasks;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import com.example.todo.dto.request.tasks.TaskSearchRequest;
+import com.example.todo.dto.response.tasks.TaskBaseResponse;
+import com.example.todo.entity.Task;
+import com.example.todo.enums.task.TaskPriority;
+import com.example.todo.service.tasks.TaskSearchService;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(TaskSearchController.class)
+class TaskSearchControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private TaskSearchService taskSearchService;
+
+  @BeforeEach
+  void setUp() {
+    LocalDateTime now = LocalDateTime.now();
+    // モックレスポンスの設定
+    Task task1 = new Task();
+    task1.setId(1);
+    task1.setName("Task 1");
+    task1.setPriority(TaskPriority.MEDIUM);
+    task1.setCreatedAt(now);
+    task1.setUpdatedAt(now);
+
+    Task task2 = new Task();
+    task2.setId(2);
+    task2.setName("Task 2");
+    task2.setPriority(TaskPriority.LOW);
+    task2.setCreatedAt(now);
+    task2.setUpdatedAt(now);
+
+    List<TaskBaseResponse> mockTasks =
+        Arrays.asList(new TaskBaseResponse(task1), new TaskBaseResponse(task2));
+
+
+    Mockito.when(this.taskSearchService.invoke(Mockito.any(TaskSearchRequest.class)))
+        .thenReturn(mockTasks);
+  }
+
+  @Test
+  void Taskの一覧が返されること() throws Exception {
+    this.mockMvc.perform(get("/api/tasks")).andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasSize(2))).andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].name").value("Task 1"))
+        .andExpect(jsonPath("$[0].priority.value").value(TaskPriority.MEDIUM.getValue()))
+        .andExpect(jsonPath("$[1].id").value(2)).andExpect(jsonPath("$[1].name").value("Task 2"))
+        .andExpect(jsonPath("$[1].priority.value").value(TaskPriority.LOW.getValue()));
+  }
+}

--- a/spring/src/test/java/com/example/todo/repository/specification/TaskSpecificationTest.java
+++ b/spring/src/test/java/com/example/todo/repository/specification/TaskSpecificationTest.java
@@ -1,0 +1,95 @@
+package com.example.todo.repository.specification;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.ActiveProfiles;
+import com.example.todo.entity.Project;
+import com.example.todo.entity.Task;
+import com.example.todo.repository.TaskRepository;
+import com.example.todo.repository.ProjectRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @DataJpaTest JPA関連のコンポーネント（リポジトリ、エンティティマネージャーなど）をテストするためのアノテーション
+ */
+@DataJpaTest
+/**
+ * @AutoConfigureTestDatabase 埋め込みデータベースの設定を無効化し、テスト用で独自で用意したデータベースを使用するためのアノテーション
+ */
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+/**
+ * @ActiveProfiles テスト用のプロファイルを指定するためのアノテーション（application-test.yml を読み込む）
+ */
+@ActiveProfiles("test")
+class TaskSpecificationTest {
+
+  @Autowired
+  private TaskRepository taskRepository;
+
+  @Autowired
+  private ProjectRepository projectRepository;
+
+  private Project project;
+
+  private TaskSpecification taskSpecification;
+
+  @BeforeEach
+  void setUp() {
+    this.taskSpecification = new TaskSpecification();
+
+    // テスト用のプロジェクトを作成し保存
+    this.project = new Project();
+    this.project.setName("Test Project");
+    this.project.setSummary("This is a test project");
+    this.projectRepository.save(this.project);
+
+    // テスト用のタスクを複数作成し保存
+    Task task1 = new Task();
+    task1.setName("Test Task 1");
+    task1.setProject(this.project);
+    this.taskRepository.save(task1);
+
+    Task task2 = new Task();
+    task2.setName("Test Task 2");
+    task2.setProject(this.project);
+    this.taskRepository.save(task2);
+
+    Task taskWithoutProject = new Task();
+    taskWithoutProject.setName("Task Without Project");
+    this.taskRepository.save(taskWithoutProject);
+  }
+
+  @Test
+  void projectIdIsNull_プロジェクトがnullのタスクを取得できること() {
+    // Specificationの作成
+    Specification<Task> spec = this.taskSpecification.projectIdIsNull();
+
+    // クエリ実行
+    List<Task> tasks = this.taskRepository.findAll(spec);
+
+    // 検証: プロジェクトがnullのタスクのみが取得されること
+    assertEquals(1, tasks.size());
+    assertTrue(tasks.get(0).getProject() == null);
+  }
+
+  @Test
+  void projectIdEqual_指定されたプロジェクトIDのタスクを取得できること() {
+    // Specificationの作成
+    Specification<Task> spec = this.taskSpecification.projectIdEqual(this.project.getId());
+
+    // クエリ実行
+    List<Task> tasks = this.taskRepository.findAll(spec);
+
+    // 検証: 取得したタスクが指定されたプロジェクトに関連付けられていること
+    assertEquals(2, tasks.size());
+    assertTrue(
+        tasks.stream().allMatch(task -> task.getProject().getId().equals(this.project.getId())));
+  }
+}

--- a/spring/src/test/java/com/example/todo/service/tasks/TaskSearchServiceTest.java
+++ b/spring/src/test/java/com/example/todo/service/tasks/TaskSearchServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.todo.service.tasks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import com.example.todo.dto.request.tasks.TaskSearchRequest;
+import com.example.todo.dto.response.tasks.TaskBaseResponse;
+import com.example.todo.entity.Task;
+import com.example.todo.repository.TaskRepository;
+
+class TaskSearchServiceTest {
+
+  @Mock
+  private TaskRepository taskRepository;
+
+  @InjectMocks
+  private TaskSearchService taskSearchService;
+
+  private LocalDateTime now = LocalDateTime.now();
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  // Mockito.any の Specification.class で警告が出ないように SuppressWarnings を指定
+  // 警告が出る理由としては、ジェネリクスの型が不明なため（本来であれば Specification<Task> と指定すべき）
+  // ただし、このテストでは Specification の具体的な型は検証する必要がないため、SuppressWarnings を指定している
+  @SuppressWarnings("unchecked")
+  @Test
+  void projectIdがnullの場合に検索が正しく行われること() {
+    // テスト用のタスクデータ
+    Task task1 = new Task();
+    task1.setId(1);
+    task1.setName("Test Task 1");
+    task1.setCreatedAt(this.now);
+    task1.setUpdatedAt(this.now);
+
+    Task task2 = new Task();
+    task2.setId(2);
+    task2.setName("Test Task 2");
+    task2.setCreatedAt(this.now);
+    task2.setUpdatedAt(this.now);
+
+    List<Task> mockTasks = List.of(task1, task2);
+
+    // リクエスト作成
+    TaskSearchRequest request = new TaskSearchRequest(null);
+
+    Mockito
+        .when(
+            this.taskRepository.findAll(Mockito.any(Specification.class), Mockito.any(Sort.class)))
+        .thenReturn(mockTasks);
+
+    // サービス実行
+    List<TaskBaseResponse> result = this.taskSearchService.invoke(request);
+
+    // 結果の検証
+    assertEquals(2, result.size());
+    assertEquals(1, result.get(0).getId());
+    assertEquals("Test Task 1", result.get(0).getName());
+    assertEquals(2, result.get(1).getId());
+    assertEquals("Test Task 2", result.get(1).getName());
+
+    // Specification の検証
+    ArgumentCaptor<Specification<Task>> specCaptor = ArgumentCaptor.forClass(Specification.class);
+    // this.taskRepository の findAll に、期待する引数で呼び出されたかを検証
+    Mockito.verify(this.taskRepository).findAll(specCaptor.capture(), Mockito.any(Sort.class));
+
+    Specification<Task> capturedSpec = specCaptor.getValue();
+    assertNotNull(capturedSpec);
+  }
+}


### PR DESCRIPTION
## 概要

- タスク一覧を取得するためのAPIを実装。
  - 並び順は、  `完了日時降順 > 締切日時昇順 > id降順`


https://github.com/user-attachments/assets/700183d1-9284-411d-9794-4b962db993b1



