### PR TITLE
test: SpringBootTest を使用しない Service Unit Test に修正

### DIFF
--- a/spring/src/test/java/com/example/todo/service/projects/ProjectCreateServiceTest.java
+++ b/spring/src/test/java/com/example/todo/service/projects/ProjectCreateServiceTest.java
@@ -2,9 +2,10 @@ package com.example.todo.service.projects;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.MockitoAnnotations;
 import com.example.todo.dto.request.projects.ProjectCreateRequest;
 import com.example.todo.entity.Project;
 import com.example.todo.repository.ProjectRepository;
@@ -12,17 +13,17 @@ import com.example.todo.repository.ProjectRepository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 
-@SpringBootTest
 class ProjectCreateServiceTest {
 
-  @MockBean
+  @Mock
   private ProjectRepository projectRepository;
 
+  @InjectMocks
   private ProjectCreateService projectCreateService;
 
   @BeforeEach
   void setUp() {
-    this.projectCreateService = new ProjectCreateService(this.projectRepository);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/spring/src/test/java/com/example/todo/service/projects/ProjectListServiceTest.java
+++ b/spring/src/test/java/com/example/todo/service/projects/ProjectListServiceTest.java
@@ -4,28 +4,29 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.MockitoAnnotations;
 import com.example.todo.entity.Project;
 import com.example.todo.repository.ProjectRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
 class ProjectListServiceTest {
 
-  @Autowired
-  private ProjectListService projectListService;
-
-  @MockBean
+  @Mock
   private ProjectRepository projectRepository;
+
+  @InjectMocks
+  private ProjectListService projectListService;
 
   private List<Project> mockProjects;
 
   @BeforeEach
   void setUp() {
+    MockitoAnnotations.openMocks(this);
+
     Project project1 = new Project();
     project1.setId(1);
     project1.setName("Project 1");


### PR DESCRIPTION
## 概要

- 本来ユニットテストでは `@SpringBootTest` は使わないそうで、インテグレーションテストとかでSpring Boot としての機能を活かしながらテストしたいときに使う？っぽい。
- Controllerでもない、今回のService のテストは、特に `@SpringBootTest` アノテーションは不要なので、 `@Mock` と `@InjectMocks` を使用したテストに修正。

## 関連するPR
- https://github.com/tatsuya-develop/spring-boot-todo-master/pull/11
- https://github.com/tatsuya-develop/spring-boot-todo-master/pull/12